### PR TITLE
cocktail visibility settings and creator info

### DIFF
--- a/src/api/badges.ts
+++ b/src/api/badges.ts
@@ -119,11 +119,11 @@ export async function fetchUserBadges(userId: string): Promise<Badge[]> {
     
     const friendCount = friendships?.length || 0;
 
-    // 3. Count events hosted (organizer_id in Event table)
+    // 3. Count events hosted (organiser_id in Event table)
     const { count: eventsHostedCount } = await supabase
       .from('Event')
       .select('*', { count: 'exact', head: true })
-      .eq('organizer_id', userId);
+      .eq('organiser_id', userId);
 
     // 4. Count events attended (EventRegistration table)
     const { count: eventsAttendedCount } = await supabase

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -24,10 +24,6 @@ export async function fetchUserSettings(userId: string): Promise<UserSettings> {
       ...defaultSettings.notifications,
       ...(data.settings.notifications || {}),
     },
-    privacy: {
-      ...defaultSettings.privacy,
-      ...(data.settings.privacy || {}),
-    },
   };
 }
 

--- a/src/components/global/FeedPostCard.tsx
+++ b/src/components/global/FeedPostCard.tsx
@@ -11,6 +11,7 @@ import { TaggedUser } from '@/src/api/tags';
 
 interface FeedPostCardProps {
   id: string;
+  cocktailId: string;
   userName: string;
   userInitials: string;
   timeAgo: string;
@@ -31,10 +32,12 @@ interface FeedPostCardProps {
   onPressComments?: () => void;
   onPressUser?: () => void;
   onPressTags?: () => void;
+  onPressCocktail?: (cocktailId: string) => void;
 }
 
 export const FeedPostCard: React.FC<FeedPostCardProps> = ({
   id,
+  cocktailId,
   userName,
   userInitials,
   timeAgo,
@@ -51,6 +54,7 @@ export const FeedPostCard: React.FC<FeedPostCardProps> = ({
   onPressComments,
   onPressUser,
   onPressTags,
+  onPressCocktail,
 }) => {
   const [shareOpen, setShareOpen] = useState(false);
   const { user } = useAuth();
@@ -161,17 +165,18 @@ export const FeedPostCard: React.FC<FeedPostCardProps> = ({
         />
         {/* Cocktail name and rating badge */}
         <Box className="absolute bottom-4 left-4 right-4 flex-row items-center justify-between">
-          <Box 
+          <Pressable 
             className="rounded-xl px-3 py-2 flex-row items-center"
             style={{
               borderWidth: 2,
               borderColor: '#14b8a6',
               backgroundColor: 'rgba(255, 255, 255, 0.95)',
             }}
+            onPress={() => onPressCocktail?.(cocktailId)}
           >
             <Text className="text-base mr-1">🍸</Text>
             <Text className="text-sm text-neutral-900">{cocktailName}</Text>
-          </Box>
+          </Pressable>
           <Box 
             className="rounded-xl px-3 py-2 flex-row items-center"
             style={{

--- a/src/screens/Add/AddScreen.tsx
+++ b/src/screens/Add/AddScreen.tsx
@@ -148,6 +148,21 @@ export const AddScreen = () => {
                 return;
             }
 
+            // Make the cocktail public only if the post is public or friends-only
+            // Private posts keep the recipe private
+            if (shareWith === 'public' || shareWith === 'friends') {
+                const { error: updateError } = await supabase
+                    .from('Cocktail')
+                    .update({ is_public: true })
+                    .eq('id', selectedCocktailId)
+                    .eq('is_public', false); // Only update if it was private
+
+                if (updateError) {
+                    console.error('Failed to update cocktail visibility:', updateError);
+                    // Don't fail the entire operation, just log the error
+                }
+            }
+
             // Add tags if any friends were selected
             if (taggedFriendIds.length > 0 && insertData) {
                 const tagResult = await addTags(insertData.id, taggedFriendIds);

--- a/src/screens/Add/LogView.tsx
+++ b/src/screens/Add/LogView.tsx
@@ -276,6 +276,15 @@ const LogView: React.FC<LogViewProps> = ({
                         description="Visible to everyone"
                     />
                 </Box>
+                
+                {/* Recipe visibility info */}
+                {(shareWith === 'public' || shareWith === 'friends') && (
+                    <Box className="mt-3 p-3 bg-blue-50 rounded-lg border border-blue-200">
+                        <Text className="text-xs text-blue-800">
+                            ℹ️ Sharing publicly or with friends will make your recipe visible to others so they can view and recreate it.
+                        </Text>
+                    </Box>
+                )}
             </Box>
 
             {/* Submit Button */}

--- a/src/screens/Explore/Pages/CocktailDetail.tsx
+++ b/src/screens/Explore/Pages/CocktailDetail.tsx
@@ -138,6 +138,19 @@ export const CocktailDetail = () => {
                     <Heading level="h3" className="mb-3">
                         {cocktail.name ?? 'Unnamed Cocktail'}
                     </Heading>
+                    
+                    {/* Creator Info - Show if it's a user-created cocktail */}
+                    {cocktail.origin_type === 'user' && (cocktail as any).Profile && (
+                        <Box className="mb-3">
+                            <HStack className="items-center gap-2">
+                                <Text className="text-sm text-neutral-600">Created by</Text>
+                                <Text className="text-sm font-semibold text-primary-500">
+                                    {((cocktail as any).Profile.full_name) || 'Unknown User'}
+                                </Text>
+                            </HStack>
+                        </Box>
+                    )}
+                    
                     <HStack className="items-center gap-4">
                         {/* Rating */}
                         <HStack className="items-center gap-1">

--- a/src/screens/Profile/Settings.tsx
+++ b/src/screens/Profile/Settings.tsx
@@ -25,9 +25,6 @@ const Settings: React.FC = () => {
 
     // Settings state
     const [settings, setSettings] = useState<UserSettings>({
-        privacy: {
-            is_private: false,
-        },
         notifications: {
             likes: true,
             comments: true,
@@ -71,16 +68,6 @@ const Settings: React.FC = () => {
             ...prev,
             notifications: {
                 ...prev.notifications,
-                [key]: value,
-            },
-        }));
-    };
-
-    const updatePrivacySetting = (key: keyof UserSettings['privacy'], value: boolean) => {
-        setSettings(prev => ({
-            ...prev,
-            privacy: {
-                ...prev.privacy,
                 [key]: value,
             },
         }));
@@ -192,23 +179,6 @@ const Settings: React.FC = () => {
                                 className={`w-12 h-6 rounded-full ${settings.notifications.comments ? 'bg-teal-500' : 'bg-neutral-200'} justify-center`}
                             >
                                 <Box className={`w-5 h-5 rounded-full bg-white shadow ${settings.notifications.comments ? 'ml-6' : 'ml-0'}`} />
-                            </Pressable>
-                        </Box>
-                    </Box>
-
-                    {/* Privacy */}
-                    <Box className="mb-4 bg-white rounded-2xl p-4">
-                        <Text className="text-base text-neutral-900 mb-3">Privacy</Text>
-                        <Box className="flex-row items-start justify-between">
-                            <Box style={{ flex: 1 }}>
-                                <Text className="text-sm font-medium text-neutral-800">Private Account</Text>
-                                <Text className="text-xs text-neutral-500">Only approved followers can see your content</Text>
-                            </Box>
-                            <Pressable 
-                                onPress={() => updatePrivacySetting('is_private', !settings.privacy.is_private)} 
-                                className={`w-12 h-6 rounded-full ${settings.privacy.is_private ? 'bg-teal-500' : 'bg-neutral-200'} justify-center`}
-                            >
-                                <Box className={`w-5 h-5 rounded-full bg-white shadow ${settings.privacy.is_private ? 'ml-6' : 'ml-0'}`} />
                             </Pressable>
                         </Box>
                     </Box>

--- a/src/screens/navigation/BottomTabs.tsx
+++ b/src/screens/navigation/BottomTabs.tsx
@@ -8,6 +8,7 @@ import { Pressable } from '@/src/components/ui/pressable';
 import { Text } from '@/src/components/ui/text';
 import { HomeIcon, SearchIcon, Users, UserIcon, PlusIcon } from 'lucide-react-native';
 import { colors } from '@/src/theme/colors';
+import { CommonActions } from '@react-navigation/native';
 
 // Import screens
 import { HomeScreen } from '@/src/screens/Home/HomeScreen';
@@ -60,6 +61,18 @@ export default function BottomTabs() {
             <Tab.Screen
                 name="Explore"
                 component={ExploreStack}
+                listeners={({ navigation }) => ({
+                    tabPress: (e) => {
+                        // Reset to the initial screen when tab is pressed
+                        e.preventDefault();
+                        navigation.dispatch(
+                            CommonActions.reset({
+                                index: 0,
+                                routes: [{ name: 'Explore' }],
+                            })
+                        );
+                    },
+                })}
                 options={{
                     tabBarIcon: ({ focused }) => (
                         <IconButton
@@ -85,6 +98,18 @@ export default function BottomTabs() {
             <Tab.Screen
                 name="Social"
                 component={SocialStack}
+                listeners={({ navigation }) => ({
+                    tabPress: (e) => {
+                        // Reset to the initial screen when tab is pressed
+                        e.preventDefault();
+                        navigation.dispatch(
+                            CommonActions.reset({
+                                index: 0,
+                                routes: [{ name: 'Social' }],
+                            })
+                        );
+                    },
+                })}
                 options={{
                     tabBarIcon: ({ focused }) => (
                         <IconButton
@@ -101,6 +126,18 @@ export default function BottomTabs() {
             <Tab.Screen
                 name="Profile"
                 component={ProfileStack}
+                listeners={({ navigation }) => ({
+                    tabPress: (e) => {
+                        // Reset to the initial screen when tab is pressed
+                        e.preventDefault();
+                        navigation.dispatch(
+                            CommonActions.reset({
+                                index: 0,
+                                routes: [{ name: 'Profile' }],
+                            })
+                        );
+                    },
+                })}
                 options={{
                     tabBarIcon: ({ focused }) => (
                         <IconButton

--- a/src/screens/navigation/TopBar.tsx
+++ b/src/screens/navigation/TopBar.tsx
@@ -277,14 +277,16 @@ export const TopBar: React.FC<TopBarProps> = ({
           {/* Logo (shown only on main pages) */}
           {showLogo ? (
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-              <Image
-                source={require('../../../assets/icon.png')}
-                style={{
-                  width: 40,
-                  height: 40,
-                  resizeMode: 'contain',
-                }}
-              />
+              <Pressable onPress={() => navigation.navigate('Home')}>
+                <Image
+                  source={require('../../../assets/icon.png')}
+                  style={{
+                    width: 40,
+                    height: 40,
+                    resizeMode: 'contain',
+                  }}
+                />
+              </Pressable>
               <Heading
                 level="h2"
                 style={{

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,7 +1,4 @@
 export type UserSettings = {
-  privacy: {
-    is_private: boolean;
-  };
   notifications: {
     likes: boolean;
     comments: boolean;
@@ -11,9 +8,6 @@ export type UserSettings = {
 };
 
 export const defaultSettings: UserSettings = {
-  privacy: {
-    is_private: false,
-  },
   notifications: {
     likes: true,
     comments: true,


### PR DESCRIPTION
This pull request introduces several user experience improvements and feature enhancements, particularly around cocktail recipe visibility, profile information, and navigation. The most notable changes are the addition of public/private logic for cocktail recipes, enhanced navigation for viewing cocktail details, and UI improvements for displaying creator information. It also removes the unused privacy settings feature from the user settings.

**Cocktail Recipe Visibility and Access**

* When sharing a drink log publicly or with friends, the associated cocktail recipe is automatically made public; private posts keep recipes private. This ensures recipes are only visible according to the post's audience. (`src/screens/Add/AddScreen.tsx`)
* Added a new API function `fetchCocktailById` to retrieve cocktail details, including creator profile info, with access control enforced by row-level security (RLS). (`src/api/cocktail.ts`)
* UI now displays an info message when a recipe will become public due to sharing settings. (`src/screens/Add/LogView.tsx`)

**Profile and Cocktail Info Display**

* Cocktail detail pages now show the creator's profile information for user-created cocktails. (`src/screens/Explore/Pages/CocktailDetail.tsx`)
* Feed posts and drink logs now include `cocktailId`, enabling navigation to cocktail details and improved data handling. (`src/screens/Home/HomeScreen.tsx`, `src/components/global/FeedPostCard.tsx`) [[1]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR63) [[2]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR347) [[3]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR357) [[4]](diffhunk://#diff-c93e0bdea687eb3d3d50ab98a4414a040fbfabc9b26200d1cbdb0f6fdab2d600R14) [[5]](diffhunk://#diff-c93e0bdea687eb3d3d50ab98a4414a040fbfabc9b26200d1cbdb0f6fdab2d600R35-R40) [[6]](diffhunk://#diff-c93e0bdea687eb3d3d50ab98a4414a040fbfabc9b26200d1cbdb0f6fdab2d600R57) [[7]](diffhunk://#diff-c93e0bdea687eb3d3d50ab98a4414a040fbfabc9b26200d1cbdb0f6fdab2d600L164-R179)

**Navigation Enhancements**

* Added handlers and props to allow users to tap on a cocktail name in a feed post to navigate directly to its detail page, fetching full data and respecting access control. (`src/screens/Home/HomeScreen.tsx`, `src/components/global/FeedPostCard.tsx`) [[1]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR520-R542) [[2]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR862) [[3]](diffhunk://#diff-10625393518aa6aef60d8fed16a2d15bc982b8d6edfef0e5c1146ce5f9b8bb4dR911) [[4]](diffhunk://#diff-c93e0bdea687eb3d3d50ab98a4414a040fbfabc9b26200d1cbdb0f6fdab2d600L164-R179)
* Bottom tab navigation now resets the stack to the initial screen when a tab is pressed, improving navigation consistency. (`src/screens/navigation/BottomTabs.tsx`) [[1]](diffhunk://#diff-e455ecd918f8d59eb4742dc69c39cfd41c8d4786404265660d1a65d8e6160b98R64-R75) [[2]](diffhunk://#diff-e455ecd918f8d59eb4742dc69c39cfd41c8d4786404265660d1a65d8e6160b98R101-R112) [[3]](diffhunk://#diff-e455ecd918f8d59eb4742dc69c39cfd41c8d4786404265660d1a65d8e6160b98R129-R140)
* The top bar logo is now clickable and navigates to the Home screen. (`src/screens/navigation/TopBar.tsx`)

**Settings and Privacy**

* Removed the privacy settings section and related logic from user settings, simplifying the settings UI and state management. (`src/api/settings.ts`, `src/screens/Profile/Settings.tsx`) [[1]](diffhunk://#diff-3c8501547f6f6c951239aeed2abcf2e47cae318a486be0154503b038bd0410b8L27-L30) [[2]](diffhunk://#diff-32ee85686c347b6bf03cbaa8f89d3957ce546c0376dee367b32b0b38d8131916L28-L30) [[3]](diffhunk://#diff-32ee85686c347b6bf03cbaa8f89d3957ce546c0376dee367b32b0b38d8131916L79-L88) [[4]](diffhunk://#diff-32ee85686c347b6bf03cbaa8f89d3957ce546c0376dee367b32b0b38d8131916L199-L215)

**Other Minor Improvements**

* Fixed a typo in the badges API: changed `organizer_id` to `organiser_id` for event host counting. (`src/api/badges.ts`)
* Public cocktail queries now include creator profile info for richer displays. (`src/api/cocktail.ts`)

Let me know if you want a deeper dive into any of these areas!